### PR TITLE
(Fix) New alias for core ceremony dApp

### DIFF
--- a/validator-guide-new.md
+++ b/validator-guide-new.md
@@ -6,7 +6,7 @@
 ## Exchange your initial keys for mining, payout and voting keys
 1. Start Chrome
 2. Connect to the network in MetaMask - click on the network name in the top left corner of plugin's window and in the dropdown list select "Custom RPC", enter URL that was provided to you by the Master of Ceremony (For Core network: [https://core.poa.network](https://core.poa.network) for Sokol testnet [https://sokol.poa.network](https://sokol.poa.network)). Wait till the MetaMask connects to the network
-3. Open Keys DApp: for Core network: [https://poanetwork.github.io/poa-dapps-keys-generation/](https://poanetwork.github.io/poa-dapps-keys-generation/), for Sokol testnet: [https://sokol-ceremony.poa.network/](https://sokol-ceremony.poa.network/)
+3. Open Keys DApp: for Core network: [https://core-ceremony.poa.network/](https://core-ceremony.poa.network/), for Sokol testnet: [https://sokol-ceremony.poa.network/](https://sokol-ceremony.poa.network/)
 4. Click "Generate keys", confirm transaction.
 5. **Be sure to copy address, password and download keystore file for each key (mining, payout, voting) without closing browser's tab**. There is no way to get this data once you close the tab. Keep it in a safe place.
 


### PR DESCRIPTION
New short alias for core ceremony dApp `https://core-ceremony.poa.network/` instead of `https://poanetwork.github.io/poa-dapps-keys-generation/` in `validator-guide-new.md`