### PR TITLE
Fix missing prefix in urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ POA Network is the first Ethereum-based public network with Proof of Authority c
 * Getting Started
     * [Installation](https://github.com/poanetwork/wiki/wiki/POA-Installation)
     * Wallets
-        * [MetaMask](POA-Network-on-MetaMask)
+        * [MetaMask](https://github.com/poanetwork/wiki/wiki/POA-Network-on-MetaMask)
         * [MEW](https://github.com/poanetwork/wiki/wiki/POA-Network-on-MEW)
         * [Ledger](https://github.com/poanetwork/wiki/wiki/POA-Network-on-Ledger)
         * [Trezor](https://github.com/poanetwork/wiki/wiki/POA-Network-on-Trezor)

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ POA Network is the first Ethereum-based public network with Proof of Authority c
     * Full/Boot Node Operator
         * [AWS](https://github.com/poanetwork/wiki/wiki/Bootnode-Setup-AWS)
         * [Non-AWS](https://github.com/poanetwork/wiki/wiki/Bootnode-Setup-Non-AWS)
-    * [Non-AWS Node Setup](Non-AWS-Node-Setup)
+    * [Non-AWS Node Setup](https://github.com/poanetwork/wiki/wiki/Non-AWS-Node-Setup)
 * Hard Forks
     * Sokol
-        * [2018-01-08](HFs-Sokol-2018-01-08)
+        * [2018-01-08](https://github.com/poanetwork/wiki/wiki/HFs-Sokol-2018-01-08)
 * POA
     * [Papers](https://github.com/poanetwork/wiki/wiki/POA-Network-Papers)
     * [What is POA](https://github.com/poanetwork/wiki/wiki/What-is-POA) WIP


### PR DESCRIPTION
A couple of links in README was missing wiki/wiki prefix in url and was leading to 404.